### PR TITLE
add username and password as secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Incredibly secure, fast and light WebDav Server, built from Nginx official image
 $ docker run --name keepass-webdav -p 80:80 -v /path/to/your/keepass/files/:/media/data -d maltokyo/docker-nginx-webdav
 ```
 
-Or use the docker-compose file included in this repository.
+Or use the [docker-compose](./docker-compose.yml) file included in this repository.
 
 No built-in TLS support. Reverse proxy with TLS recommended
 
@@ -18,6 +18,35 @@ No built-in TLS support. Reverse proxy with TLS recommended
 To restrict access to only authorized users (recommended), you can define two environment variables: `$USERNAME` and `$PASSWORD`
 ```console
 $ docker run --name webdav -p 80:80 -v /path/to/your/shared/files/:/media/data -e USERNAME=webdav -e PASSWORD=webdav -d maltokyo/docker-nginx-webdav
+
+```
+Or use docker-compose example with secret
+```nano
+version: "3.9"
+name: webdav
+secrets:
+  USERNAME_SC:
+    file: <path-to-your-secret>/username.secret.txt
+  PASSWORD_SC:
+    file:  <path-to-your-secret>/password.secret.txt
+services:
+  docker-nginx-webdav:
+    #image: djonko/docker-nginx-webdav
+    build: .
+    container_name: webdav
+    restart: unless-stopped
+    security_opt:
+      - no-new-privileges:true
+    ports:
+      - "80:80"
+    volumes:
+      - "<path-you-want-to-share>:/media/data"
+    secrets:
+      - USERNAME_SC
+      - PASSWORD_SC
+    environment:
+      - USERNAME_FILE=/run/secrets/USERNAME_SC
+      - PASSWORD_FILE=/run/secrets/PASSWORD_SC
 
 ```
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
+if [[ -n "$USERNAME_FILE" ]] && [[ -n "$PASSWORD_FILE" ]]
+then
+  USERNAME=$(cat "$USERNAME_FILE")
+  PASSWORD=$(cat "$PASSWORD_FILE")
+fi
 
 if [[ -n "$USERNAME" ]] && [[ -n "$PASSWORD" ]]
 then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ fi
 
 if [[ -n "$USERNAME" ]] && [[ -n "$PASSWORD" ]]
 then
-	htpasswd -bc /etc/nginx/htpasswd $USERNAME $PASSWORD
+	htpasswd -bc /etc/nginx/htpasswd "$USERNAME" "$PASSWORD"
 	echo Done.
 else
     echo Using no auth.


### PR DESCRIPTION
Add secrets feature for username and password properties. 
Example : 
```
version: "3.9"
name: webdav

secrets:
  USERNAME_SC:
    file: $HOME/webdav-data/username.secret.txt
  PASSWORD_SC:
    file: $HOME/webdav-data/password.secret.txt
services:
  docker-nginx-webdav:
    image: djonko/nginx_webdav
    container_name: data-webdav
    restart: unless-stopped
    security_opt:
      - no-new-privileges:true
    ports:
      - "8101:80"
    volumes:
      - "/mnt/data/:/media/data"
    secrets:
      - USERNAME_SC
      - PASSWORD_SC
    environment:
      - USERNAME_FILE=/run/secrets/USERNAME_SC
      - PASSWORD_FILE=/run/secrets/PASSWORD_SC
```