### PR TITLE
fix: use debian-13 as base image and fix volume ownership

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,14 @@
-FROM nginx:latest
+FROM debian:13-slim
 
 LABEL maintainer="maltokyo"
 
-RUN apt-get update && apt-get dist-upgrade -y && apt-get install -y nginx-extras apache2-utils
+RUN apt-get update && apt-get install -y nginx nginx-extras apache2-utils
 
 
 COPY webdav.conf /etc/nginx/conf.d/default.conf
 RUN rm /etc/nginx/sites-enabled/*
 
-
-RUN mkdir -p "/media/data"
-
-RUN chown -R www-data:www-data "/media/data"
-
 VOLUME /media/data
-
 
 COPY entrypoint.sh /
 RUN chmod +x entrypoint.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   nginx_webdav:
 #    image: maltokyo/docker-nginx-webdav # comment out this line if you are building from source.
@@ -6,7 +5,7 @@ services:
 #    ports: # enable this if you are not using reverse proxy, otherwise leave commented out
 #      - "80:80"
     volumes:
-      - "/path/to/your/share:/media/data"
+      - "./data:/media/data"
     environment:
       USERNAME: your_webdav_user
       PASSWORD: your_webdav_passwd

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,3 +14,5 @@ else
 	sed -i 's%auth_basic "Restricted";% %g' /etc/nginx/conf.d/default.conf
 	sed -i 's%auth_basic_user_file /etc/nginx/htpasswd;% %g' /etc/nginx/conf.d/default.conf
 fi
+
+chown -R www-data:www-data "/media/data"


### PR DESCRIPTION
The original Dockerfile leads to failed installation due to broken dependency.

I use debian:13-slim as the base image and install nginx manually.

Additionally, the `chown` command in Dockerfile is not effective since bind mounting happens after image building. Therefore, I move the `chown` to `entrypoint.sh`.